### PR TITLE
add username of user in email

### DIFF
--- a/lib/afc/email.ex
+++ b/lib/afc/email.ex
@@ -20,6 +20,7 @@ defmodule Afc.Email do
     """
     <strong>#{emotion_log.emotion}</strong>
     <p>#{logged_at}</p>
+    <p>username: #{emotion_log.user.username}</p>
     <p>reason list:</p>
     #{list_reasons(emotion)}
     <p>reason text:</p>


### PR DESCRIPTION
ref: https://github.com/actnforchildren/mental_health_app/issues/13#issuecomment-434265457

Add the username of the user who shared the emotion log with the trusted adult